### PR TITLE
#15 : ENHC : Refactoring Thulawa Metrics with proper design pattern

### DIFF
--- a/src/main/java/com/thulawa/kafka/ThulawaKafkaStreams.java
+++ b/src/main/java/com/thulawa/kafka/ThulawaKafkaStreams.java
@@ -5,9 +5,13 @@
 
 package com.thulawa.kafka;
 
+import com.thulawa.kafka.internals.configs.ThulawaStreamsConfig;
 import com.thulawa.kafka.internals.metrics.ThulawaMetrics;
-import com.thulawa.kafka.internals.metrics.ThulawaMetricsRecorder;
 import com.thulawa.kafka.internals.suppliers.ThulawaClientSupplier;
+import org.apache.kafka.clients.CommonClientConfigs;
+import org.apache.kafka.common.metrics.JmxReporter;
+import org.apache.kafka.common.metrics.KafkaMetricsContext;
+import org.apache.kafka.common.metrics.MetricConfig;
 import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.streams.KafkaStreams;
@@ -15,30 +19,30 @@ import org.apache.kafka.streams.Topology;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Collections;
 import java.util.Properties;
 
+import static com.thulawa.kafka.internals.metrics.ThulawaMetrics.THULAWA_METRICS_NAMESPACE;
+
 public class ThulawaKafkaStreams extends KafkaStreams {
+
     private static final Logger LOG = LoggerFactory.getLogger(ThulawaKafkaStreams.class);
+
+    public static final String THULAWA_METRICS_CONFIG = "__thulawa.metrics.config__";
+
     private ThulawaClientSupplier thulawaClientSupplier;
     private final ThulawaMetrics thulawaMetrics;
-    private final ThulawaMetricsRecorder thulawaMetricsRecorder;
 
     public ThulawaKafkaStreams(Topology topology, Properties props) {
-        this(topology, props, Time.SYSTEM);
+        this( new UpdatedParameters(topology, props) );
     }
 
-//    public ThulawaKafkaStreams(Topology topology, Map<?, ?> configs, KafkaClientSupplier clientSupplier) {
-//        this(topology, configs, clientSupplier, Time.SYSTEM);
-//    }
-
-    public ThulawaKafkaStreams(Topology topology, Properties props, Time time) {
-        super(topology, props, new ThulawaClientSupplier(), time);
+    public ThulawaKafkaStreams( UpdatedParameters updatedParameters ) {
+        super(updatedParameters.topology, updatedParameters.props, updatedParameters.clientSupplier, Time.SYSTEM);
 
         // Have to properly update the metrics exposing with a proper design pattern
         // This is temporary, and will be updated in the later enhancements
-        this.thulawaMetrics = new ThulawaMetrics(new Metrics());
-        this.thulawaMetricsRecorder = new ThulawaMetricsRecorder(this.thulawaMetrics);
+        this.thulawaMetrics = (ThulawaMetrics) updatedParameters.props.get(THULAWA_METRICS_CONFIG);
     }
-
 
 }

--- a/src/main/java/com/thulawa/kafka/UpdatedParameters.java
+++ b/src/main/java/com/thulawa/kafka/UpdatedParameters.java
@@ -1,0 +1,60 @@
+package com.thulawa.kafka;
+
+import com.thulawa.kafka.internals.configs.ThulawaStreamsConfig;
+import com.thulawa.kafka.internals.metrics.ThulawaMetrics;
+import com.thulawa.kafka.internals.suppliers.ThulawaClientSupplier;
+import org.apache.kafka.common.metrics.JmxReporter;
+import org.apache.kafka.common.metrics.KafkaMetricsContext;
+import org.apache.kafka.common.metrics.MetricConfig;
+import org.apache.kafka.common.metrics.Metrics;
+import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.streams.Topology;
+
+import java.util.Collections;
+import java.util.Properties;
+
+import static com.thulawa.kafka.ThulawaKafkaStreams.THULAWA_METRICS_CONFIG;
+import static com.thulawa.kafka.internals.metrics.ThulawaMetrics.THULAWA_METRICS_NAMESPACE;
+
+public class UpdatedParameters {
+
+    public final Topology topology;
+    public final Properties props;
+    public final ThulawaClientSupplier clientSupplier;
+
+    public UpdatedParameters(Topology topology, Properties props) {
+        this.topology = topology;
+        this.props = initializeThulawaMetrics(props);
+        this.clientSupplier = new ThulawaClientSupplier();
+    }
+
+    /**
+     * Creates and integrates Thulawa-specific metrics into the provided properties.
+     *
+     * @param originalProps Original properties passed to the constructor.
+     * @return A new Properties object with updated metrics configuration.
+     */
+    private Properties initializeThulawaMetrics(Properties originalProps) {
+        // Create a copy of the original properties to avoid mutation
+        Properties updatedProps = new Properties();
+        updatedProps.putAll(originalProps);
+
+        // Configure the Kafka Metrics
+        MetricConfig metricConfig = new MetricConfig();
+        JmxReporter jmxReporter = new JmxReporter();
+        jmxReporter.configure(ThulawaStreamsConfig.cerateThulawaStreamsConfig(originalProps).originals());
+
+        // Create ThulawaMetrics with a custom Metrics object
+        ThulawaMetrics thulawaMetrics = new ThulawaMetrics(new Metrics(
+                metricConfig,
+                Collections.singletonList(jmxReporter),
+                Time.SYSTEM,
+                new KafkaMetricsContext(THULAWA_METRICS_NAMESPACE)
+        ));
+
+        // Add the ThulawaMetrics instance to the properties
+        updatedProps.put(THULAWA_METRICS_CONFIG, thulawaMetrics);
+
+        return updatedProps;
+    }
+}

--- a/src/main/java/com/thulawa/kafka/internals/configs/ThulawaStreamsConfig.java
+++ b/src/main/java/com/thulawa/kafka/internals/configs/ThulawaStreamsConfig.java
@@ -1,0 +1,21 @@
+package com.thulawa.kafka.internals.configs;
+
+import org.apache.kafka.streams.StreamsConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+
+public class ThulawaStreamsConfig extends StreamsConfig {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ThulawaStreamsConfig.class);
+
+    public static ThulawaStreamsConfig cerateThulawaStreamsConfig(final Map<?, ?> props) {
+        return new ThulawaStreamsConfig(props);
+    }
+
+    private ThulawaStreamsConfig(Map<?, ?> props) {
+        super(props);
+    }
+
+}

--- a/src/main/java/com/thulawa/kafka/internals/metrics/JVMMetricsRecorder.java
+++ b/src/main/java/com/thulawa/kafka/internals/metrics/JVMMetricsRecorder.java
@@ -1,0 +1,129 @@
+package com.thulawa.kafka.internals.metrics;
+
+import org.apache.kafka.common.MetricName;
+import org.apache.kafka.common.metrics.Measurable;
+import org.apache.kafka.common.metrics.Sensor;
+import org.apache.kafka.common.metrics.stats.Avg;
+import org.apache.kafka.common.metrics.stats.CumulativeSum;
+import org.apache.kafka.common.metrics.stats.Max;
+
+import java.lang.management.ManagementFactory;
+import java.lang.management.MemoryMXBean;
+import java.lang.management.OperatingSystemMXBean;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+public class JVMMetricsRecorder implements AutoCloseable {
+    private static final String METRIC_GROUP_NAME = "thulawa-jvm-metrics";
+
+    private final ThulawaMetrics metrics;
+    private final Sensor heapMemorySensor;
+    private final Sensor cpuUsageSensor;
+    private final MetricName heapMemoryUsedMetric;
+    private final MetricName heapMemoryMaxMetric;
+    private final MetricName cpuUsageMetric;
+
+    private final MemoryMXBean memoryMXBean;
+    private final OperatingSystemMXBean osMXBean;
+
+    private final ScheduledExecutorService scheduler;
+
+    public JVMMetricsRecorder(ThulawaMetrics metrics) {
+        this.metrics = metrics;
+        this.memoryMXBean = ManagementFactory.getMemoryMXBean();
+        this.osMXBean = ManagementFactory.getOperatingSystemMXBean();
+
+        // Scheduler for periodic recording
+        this.scheduler = Executors.newSingleThreadScheduledExecutor();
+
+        // Register Heap Memory Metrics
+        this.heapMemorySensor = metrics.addSensor("heap-memory-sensor");
+        this.heapMemoryUsedMetric = metrics.createMetricName(
+                "heap-memory-used",
+                METRIC_GROUP_NAME,
+                "The amount of heap memory currently used."
+        );
+        this.heapMemoryMaxMetric = metrics.createMetricName(
+                "heap-memory-max",
+                METRIC_GROUP_NAME,
+                "The maximum amount of heap memory available."
+        );
+        this.heapMemorySensor.add(heapMemoryUsedMetric, new CumulativeSum());
+        this.heapMemorySensor.add(heapMemoryMaxMetric, new Max());
+
+        // Register CPU Usage Metrics
+        this.cpuUsageSensor = metrics.addSensor("cpu-usage-sensor");
+        this.cpuUsageMetric = metrics.createMetricName(
+                "cpu-usage",
+                METRIC_GROUP_NAME,
+                "The system-wide CPU usage as a percentage."
+        );
+        this.cpuUsageSensor.add(cpuUsageMetric, new Avg());
+
+        // Register Measurable Metrics
+        registerMeasurableMetrics();
+
+        // Schedule the periodic recording of metrics every 5 seconds
+        scheduleMetricRecording();
+    }
+
+    private void registerMeasurableMetrics() {
+        // Heap memory used (measurable)
+        metrics.addMetric(heapMemoryUsedMetric, (Measurable) (config, now) ->
+                (double) memoryMXBean.getHeapMemoryUsage().getUsed());
+
+        // Heap memory max (measurable)
+        metrics.addMetric(heapMemoryMaxMetric, (Measurable) (config, now) ->
+                (double) memoryMXBean.getHeapMemoryUsage().getMax());
+
+        // CPU usage (measurable)
+        if (osMXBean instanceof com.sun.management.OperatingSystemMXBean) {
+            metrics.addMetric(cpuUsageMetric, (Measurable) (config, now) ->
+                    ((com.sun.management.OperatingSystemMXBean) osMXBean).getSystemCpuLoad() * 100);
+        }
+    }
+
+    private void scheduleMetricRecording() {
+        scheduler.scheduleAtFixedRate(() -> {
+            try {
+                recordMetrics();
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+        }, 0, 5, TimeUnit.SECONDS); // Schedule every 5 seconds
+    }
+
+    public void recordMetrics() {
+        long usedHeapMemory = memoryMXBean.getHeapMemoryUsage().getUsed();
+        long maxHeapMemory = memoryMXBean.getHeapMemoryUsage().getMax();
+        double cpuLoad = osMXBean instanceof com.sun.management.OperatingSystemMXBean
+                ? ((com.sun.management.OperatingSystemMXBean) osMXBean).getSystemCpuLoad() * 100
+                : 0.0;
+
+        // Record metrics to sensors
+        heapMemorySensor.record(usedHeapMemory);
+        heapMemorySensor.record(maxHeapMemory);
+        cpuUsageSensor.record(cpuLoad);
+    }
+
+    @Override
+    public void close() {
+        // Shut down the scheduler
+        scheduler.shutdown();
+        try {
+            if (!scheduler.awaitTermination(5, TimeUnit.SECONDS)) {
+                scheduler.shutdownNow();
+            }
+        } catch (InterruptedException e) {
+            scheduler.shutdownNow();
+        }
+
+        // Remove sensors and metrics
+        metrics.removeSensor(heapMemorySensor.name());
+        metrics.removeSensor(cpuUsageSensor.name());
+        metrics.removeMetric(heapMemoryUsedMetric);
+        metrics.removeMetric(heapMemoryMaxMetric);
+        metrics.removeMetric(cpuUsageMetric);
+    }
+}

--- a/src/main/java/com/thulawa/kafka/internals/metrics/ThulawaMetrics.java
+++ b/src/main/java/com/thulawa/kafka/internals/metrics/ThulawaMetrics.java
@@ -1,16 +1,12 @@
 package com.thulawa.kafka.internals.metrics;
 
 import org.apache.kafka.common.MetricName;
-import org.apache.kafka.common.metrics.KafkaMetric;
-import org.apache.kafka.common.metrics.MetricValueProvider;
-import org.apache.kafka.common.metrics.Metrics;
-import org.apache.kafka.common.metrics.Sensor;
+import org.apache.kafka.common.metrics.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.Closeable;
 import java.io.IOException;
-import java.util.LinkedHashMap;
 import java.util.Map;
 
 public class ThulawaMetrics implements Closeable {
@@ -24,8 +20,12 @@ public class ThulawaMetrics implements Closeable {
         this.metrics = metrics;
     }
 
-    public void addMetric(final MetricName metricName, final MetricValueProvider<?> valueProvider) {
-        metrics.addMetric(metricName, valueProvider);
+    public void addMetric(final MetricName metricName, final Measurable measurable) {
+        metrics.addMetric(metricName, measurable);
+    }
+
+    public MetricName createMetricName(String name, String group, String description) {
+        return metrics.metricName(name, group, description);
     }
 
     public Sensor addSensor(final String sensorName) {

--- a/src/main/java/com/thulawa/kafka/internals/processor/ThulawaProcessor.java
+++ b/src/main/java/com/thulawa/kafka/internals/processor/ThulawaProcessor.java
@@ -3,11 +3,17 @@ package com.thulawa.kafka.internals.processor;
 import com.thulawa.kafka.ThulawaTaskManager;
 import com.thulawa.kafka.internals.helpers.QueueManager;
 import com.thulawa.kafka.internals.helpers.ThreadPoolRegistry;
+import com.thulawa.kafka.internals.metrics.ThulawaMetrics;
 import com.thulawa.kafka.scheduler.ThulawaScheduler;
+import org.apache.kafka.common.metrics.Metrics;
+import org.apache.kafka.streams.StreamsMetrics;
 import org.apache.kafka.streams.processor.api.Processor;
+import org.apache.kafka.streams.processor.api.ProcessorContext;
 import org.apache.kafka.streams.processor.api.Record;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import static com.thulawa.kafka.ThulawaKafkaStreams.THULAWA_METRICS_CONFIG;
 
 /**
  * ThulawaProcessor processes Kafka records and manages key-based queues dynamically.
@@ -16,16 +22,31 @@ public class ThulawaProcessor<KIn, VIn, KOut, VOut> implements Processor<KIn, VI
 
     private static final Logger logger = LoggerFactory.getLogger(ThulawaProcessor.class);
 
-    private final QueueManager queueManager;
-    private final ThreadPoolRegistry threadPoolRegistry;
-    private final ThulawaScheduler thulawaScheduler;
-    private final ThulawaTaskManager thulawaTaskManager;
+    private QueueManager queueManager;
+    private ThreadPoolRegistry threadPoolRegistry;
+    private ThulawaScheduler thulawaScheduler;
+    private ThulawaTaskManager thulawaTaskManager;
+    private ThulawaMetrics thulawaMetrics;
+
+    private Processor processor;
+    private ProcessorContext processorContext;
 
     public ThulawaProcessor(Processor processor) {
+        this.processor = processor;
+    }
+
+    @Override
+    public void init(ProcessorContext<KOut, VOut> context) {
+
+        this.processorContext = context;
+
+        this.thulawaMetrics = (ThulawaMetrics) context.appConfigs().get(THULAWA_METRICS_CONFIG);
+
         this.queueManager = QueueManager.getInstance();
         this.threadPoolRegistry = ThreadPoolRegistry.getInstance();
         this.thulawaTaskManager = new ThulawaTaskManager(this.threadPoolRegistry);
-        this.thulawaScheduler = ThulawaScheduler.getInstance(this.queueManager, this.threadPoolRegistry, this.thulawaTaskManager, processor);
+        this.thulawaScheduler = ThulawaScheduler.getInstance(this.queueManager, this.threadPoolRegistry,
+                this.thulawaTaskManager, thulawaMetrics, processor);
 
     }
 

--- a/src/main/java/com/thulawa/kafka/internals/suppliers/ThulawaClientSupplier.java
+++ b/src/main/java/com/thulawa/kafka/internals/suppliers/ThulawaClientSupplier.java
@@ -2,7 +2,6 @@ package com.thulawa.kafka.internals.suppliers;
 
 import com.thulawa.kafka.internals.clients.ThulawaConsumer;
 import org.apache.kafka.clients.consumer.Consumer;
-import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.common.serialization.ByteArrayDeserializer;
 import org.apache.kafka.streams.processor.internals.DefaultKafkaClientSupplier;
 

--- a/src/main/java/com/thulawa/kafka/scheduler/ThulawaScheduler.java
+++ b/src/main/java/com/thulawa/kafka/scheduler/ThulawaScheduler.java
@@ -4,6 +4,9 @@ import com.thulawa.kafka.ThulawaTask;
 import com.thulawa.kafka.ThulawaTaskManager;
 import com.thulawa.kafka.internals.helpers.QueueManager;
 import com.thulawa.kafka.internals.helpers.ThreadPoolRegistry;
+import com.thulawa.kafka.internals.metrics.ThulawaMetrics;
+import org.apache.kafka.common.metrics.Metrics;
+import org.apache.kafka.streams.StreamsMetrics;
 import org.apache.kafka.streams.processor.api.Processor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -23,21 +26,26 @@ public class ThulawaScheduler implements Scheduler{
     private final ThulawaTaskManager thulawaTaskManager;
     private final Processor processor;
 
+    private final ThulawaMetrics thulawaMetrics;
+
     private State state;
 
-    private ThulawaScheduler(QueueManager queueManager, ThreadPoolRegistry threadPoolRegistry, ThulawaTaskManager thulawaTaskManager, Processor processor) {
+    private ThulawaScheduler(QueueManager queueManager, ThreadPoolRegistry threadPoolRegistry, ThulawaTaskManager thulawaTaskManager,
+                             ThulawaMetrics thulawaMetrics, Processor processor) {
         this.queueManager = queueManager;
         this.threadPoolRegistry = threadPoolRegistry;
         this.thulawaTaskManager = thulawaTaskManager;
+        this.thulawaMetrics = thulawaMetrics;
         this.processor = processor;
         this.state = State.CREATED;
 
         this.queueManager.setSchedulerObserver(this);
     }
 
-    public static synchronized ThulawaScheduler getInstance(QueueManager queueManager, ThreadPoolRegistry threadPoolRegistry, ThulawaTaskManager thulawaTaskManager, Processor processor) {
+    public static synchronized ThulawaScheduler getInstance(QueueManager queueManager, ThreadPoolRegistry threadPoolRegistry, ThulawaTaskManager thulawaTaskManager,
+                                                            ThulawaMetrics thulawaMetrics, Processor processor) {
         if (instance == null) {
-            instance = new ThulawaScheduler(queueManager, threadPoolRegistry, thulawaTaskManager, processor);
+            instance = new ThulawaScheduler(queueManager, threadPoolRegistry, thulawaTaskManager, thulawaMetrics, processor);
         }
         return instance;
     }


### PR DESCRIPTION
With these updates, A ThulawaMetrics object will be created and will be saved as a Stream config and then it can be accessed using the THULAWA_METRICS_CONFIG from the processor context which is present in the ThulawaProcessor.

Also initial recorder class related to issue - #22, which is to manage JVM metrics is also included in this commit.