### PR TITLE
#32 : ENHC : Implement the Filtering based on the Key

### DIFF
--- a/src/main/java/com/thulawa/kafka/UpdatedParameters.java
+++ b/src/main/java/com/thulawa/kafka/UpdatedParameters.java
@@ -1,5 +1,6 @@
 package com.thulawa.kafka;
 
+import com.thulawa.kafka.internals.configs.ThulawaConfigs;
 import com.thulawa.kafka.internals.configs.ThulawaStreamsConfig;
 import com.thulawa.kafka.internals.metrics.ThulawaMetrics;
 import com.thulawa.kafka.internals.suppliers.ThulawaClientSupplier;
@@ -11,7 +12,9 @@ import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.streams.Topology;
 
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Properties;
+import java.util.Set;
 
 import static com.thulawa.kafka.ThulawaKafkaStreams.THULAWA_METRICS_CONFIG;
 import static com.thulawa.kafka.internals.metrics.ThulawaMetrics.THULAWA_METRICS_NAMESPACE;
@@ -21,6 +24,8 @@ public class UpdatedParameters {
     public final Topology topology;
     public final Properties props;
     public final ThulawaClientSupplier clientSupplier;
+
+    public static final Set<String> highPriorityKeySet = new HashSet<>();
 
     public UpdatedParameters(Topology topology, Properties props) {
         this.topology = topology;
@@ -55,6 +60,17 @@ public class UpdatedParameters {
         // Add the ThulawaMetrics instance to the properties
         updatedProps.put(THULAWA_METRICS_CONFIG, thulawaMetrics);
 
+        //write the code to get the keys seperated from commas and add to the map
+        String highPriorityKeyList = originalProps.getProperty(ThulawaConfigs.HIGH_PRIORITY_KEY_LIST);
+        if (highPriorityKeyList != null && !highPriorityKeyList.isEmpty()) {
+            // Split the comma-separated string and add the keys to the set
+            String[] keys = highPriorityKeyList.split(",");
+            for (String key : keys) {
+                highPriorityKeySet.add(key.trim()); // Trim to avoid leading/trailing spaces
+            }
+        }
+
+        updatedProps.put(ThulawaConfigs.HIGH_PRIORITY_KEY_MAP, highPriorityKeySet);
         return updatedProps;
     }
 }

--- a/src/main/java/com/thulawa/kafka/internals/configs/ThulawaConfigs.java
+++ b/src/main/java/com/thulawa/kafka/internals/configs/ThulawaConfigs.java
@@ -6,7 +6,28 @@ import org.apache.kafka.common.config.ConfigDef;
 import java.util.Map;
 
 public class ThulawaConfigs extends AbstractConfig {
-    public ThulawaConfigs(ConfigDef definition, Map<?, ?> originals, boolean doLog) {
-        super(definition, originals, doLog);
+
+    public static final String HIGH_PRIORITY_KEY_LIST = "high.priority.key.list";
+    public static final String HIGH_PRIORITY_KEY_LIST_DESCRIPTION = "Comma separated High Priority Keys";
+
+    public static final String HIGH_PRIORITY_KEY_MAP = "high.priority.key.map";
+    public static final String HIGH_PRIORITY_KEY_MAP_DESCRIPTION = "Map of the High Priority Keys";
+
+    private static final ConfigDef definition = new ConfigDef()
+            .define(
+                    HIGH_PRIORITY_KEY_LIST,
+                    ConfigDef.Type.STRING,
+                    ConfigDef.Importance.HIGH,
+                    HIGH_PRIORITY_KEY_LIST_DESCRIPTION
+            )
+            .define(
+                    HIGH_PRIORITY_KEY_MAP,
+                    ConfigDef.Type.CLASS,
+                    ConfigDef.Importance.HIGH,
+                    HIGH_PRIORITY_KEY_MAP_DESCRIPTION
+            );
+
+    public ThulawaConfigs(ConfigDef definition, Map<?, ?> originals) {
+        super(definition, originals);
     }
 }

--- a/src/main/java/com/thulawa/kafka/internals/helpers/QueueManager.java
+++ b/src/main/java/com/thulawa/kafka/internals/helpers/QueueManager.java
@@ -7,6 +7,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
@@ -18,7 +19,7 @@ public class QueueManager {
 
     private static QueueManager instance;
 
-    private static final String NULL_KEY_QUEUE = "__NULL_KEY__";
+    private static final String COMMON_QUEUE_KEY = "low.priority.keys";
 
     // Map to hold queues for each key
     private final Map<String, KeyBasedQueue> queues = new ConcurrentHashMap<>();
@@ -26,28 +27,42 @@ public class QueueManager {
     // Map to track the size of each queue
     private final Map<String, Integer> queueSizeMap = new ConcurrentHashMap<>();
 
+    private final Set<String> highPriorityKeySet;
+
     private Scheduler schedulerObserver;
 
-    private QueueManager() {
+    private QueueManager(Set<String> highPriorityKeySet) {
+        this.highPriorityKeySet = highPriorityKeySet;
     }
 
-    public static synchronized QueueManager getInstance() {
+    public static synchronized QueueManager getInstance(Set<String> highPriorityKeySet) {
         if (instance == null) {
-            instance = new QueueManager();
+            instance = new QueueManager(highPriorityKeySet);
         }
         return instance;
     }
 
     /**
-     * Adds a record to the queue associated with the given key.
-     * If the queue doesn't exist, it is created.
+     * Adds a record to the appropriate queue based on the key.
+     * For high-priority keys, a dedicated queue is created.
+     * For all other keys, records are added to a common queue: "low.priority.keys".
      *
      * @param key    The key for the queue (nullable).
      * @param record The record to add.
      */
     public void addToKeyBasedQueue(String key, Record record) {
-        String queueKey = key == null ? NULL_KEY_QUEUE : key;
-        queues.computeIfAbsent(queueKey, k -> new KeyBasedQueue(key));
+        String queueKey;
+
+        // Determine the appropriate queue based on whether the key is high priority
+        if (key != null && highPriorityKeySet.contains(key)) {
+            queueKey = key; // High-priority keys get their own queue
+            queues.computeIfAbsent(queueKey, k -> new KeyBasedQueue(key));
+        } else {
+            queueKey = COMMON_QUEUE_KEY; // Low-priority keys go to a common queue
+            queues.computeIfAbsent(queueKey, k -> new KeyBasedQueue(COMMON_QUEUE_KEY));
+        }
+
+        // Add the record to the determined queue
         queues.get(queueKey).add(record);
         updateQueueSizeMap(queueKey);
 
@@ -59,12 +74,21 @@ public class QueueManager {
 
     /**
      * Retrieves and removes a record from the queue associated with the given key.
+     * For non-high-priority keys, retrieves records from the common queue: "low.priority.keys".
      *
-     * @param key The key for the queue.
+     * @param key The key for the queue (nullable).
      * @return The retrieved record, or null if the queue is empty or doesn't exist.
      */
     public Record getRecordFromQueue(String key) {
-        String queueKey = key == null ? NULL_KEY_QUEUE : key;
+        String queueKey;
+
+        // Determine the appropriate queue to retrieve from
+        if (key != null && highPriorityKeySet.contains(key)) {
+            queueKey = key;
+        } else {
+            queueKey = COMMON_QUEUE_KEY;
+        }
+
         KeyBasedQueue queue = queues.get(queueKey);
         if (queue == null) {
             return null;
@@ -76,18 +100,26 @@ public class QueueManager {
 
     /**
      * Gets the current size of the queue associated with the given key.
+     * For non-high-priority keys, gets the size of the common queue: "low.priority.keys".
      *
-     * @param key The key for the queue.
+     * @param key The key for the queue (nullable).
      * @return The size of the queue, or 0 if the queue doesn't exist.
      */
     public int getQueueSize(String key) {
-        String queueKey = key == null ? NULL_KEY_QUEUE : key;
+        String queueKey;
+
+        // Determine the appropriate queue to check size
+        if (key != null && highPriorityKeySet.contains(key)) {
+            queueKey = key;
+        } else {
+            queueKey = COMMON_QUEUE_KEY;
+        }
+
         KeyBasedQueue queue = queues.get(queueKey);
         return queue != null ? queue.size() : 0;
     }
 
     /**
-     * !!!!!!! Must be added to metrics and values should be taken to scheduler from metrics? !!!!!
      * Updates the queue size map to reflect the current size of the queue.
      *
      * @param key The key for the queue.
@@ -103,12 +135,21 @@ public class QueueManager {
 
     /**
      * Retrieves the size of the queue from the size map (cached value).
+     * For non-high-priority keys, retrieves the cached size of the common queue: "low.priority.keys".
      *
-     * @param key The key for the queue.
+     * @param key The key for the queue (nullable).
      * @return The cached size of the queue, or 0 if the queue doesn't exist in the map.
      */
     public int getCachedQueueSize(String key) {
-        String queueKey = key == null ? NULL_KEY_QUEUE : key;
+        String queueKey;
+
+        // Determine the appropriate queue to check cached size
+        if (key != null && highPriorityKeySet.contains(key)) {
+            queueKey = key;
+        } else {
+            queueKey = COMMON_QUEUE_KEY;
+        }
+
         return queueSizeMap.getOrDefault(queueKey, 0);
     }
 
@@ -129,5 +170,4 @@ public class QueueManager {
     public void setSchedulerObserver(Scheduler observer) {
         this.schedulerObserver = observer;
     }
-
 }

--- a/src/main/java/com/thulawa/kafka/internals/processor/ThulawaProcessor.java
+++ b/src/main/java/com/thulawa/kafka/internals/processor/ThulawaProcessor.java
@@ -12,7 +12,11 @@ import org.apache.kafka.streams.processor.api.Record;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.HashSet;
+import java.util.Set;
+
 import static com.thulawa.kafka.ThulawaKafkaStreams.THULAWA_METRICS_CONFIG;
+import static com.thulawa.kafka.internals.configs.ThulawaConfigs.HIGH_PRIORITY_KEY_MAP;
 
 /**
  * ThulawaProcessor processes Kafka records and manages key-based queues dynamically.
@@ -44,11 +48,11 @@ public class ThulawaProcessor<KIn, VIn, KOut, VOut> implements Processor<KIn, VI
         this.thulawaMetrics = (ThulawaMetrics) context.appConfigs().get(THULAWA_METRICS_CONFIG);
 
         initializeRecoders(this.thulawaMetrics);
-        this.queueManager = QueueManager.getInstance();
+        this.queueManager = QueueManager.getInstance((Set<String>) context.appConfigs().get(HIGH_PRIORITY_KEY_MAP));
         this.threadPoolRegistry = ThreadPoolRegistry.getInstance();
         this.thulawaTaskManager = new ThulawaTaskManager(this.threadPoolRegistry);
         this.thulawaScheduler = ThulawaScheduler.getInstance(this.queueManager, this.threadPoolRegistry,
-                this.thulawaTaskManager, thulawaMetrics, processor);
+                this.thulawaTaskManager, thulawaMetrics, processor, (Set<String>) context.appConfigs().get(HIGH_PRIORITY_KEY_MAP));
 
     }
 

--- a/src/main/java/com/thulawa/kafka/scheduler/ThulawaScheduler.java
+++ b/src/main/java/com/thulawa/kafka/scheduler/ThulawaScheduler.java
@@ -6,14 +6,17 @@ import com.thulawa.kafka.internals.helpers.QueueManager;
 import com.thulawa.kafka.internals.helpers.ThreadPoolRegistry;
 import com.thulawa.kafka.internals.metrics.ThulawaMetrics;
 import org.apache.kafka.streams.processor.api.Processor;
+import org.apache.kafka.streams.processor.api.Record;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Set;
+
 import static com.thulawa.kafka.internals.helpers.ThreadPoolRegistry.HIGH_PRIORITY_THREAD_POOL;
+import static com.thulawa.kafka.internals.helpers.ThreadPoolRegistry.LOW_PRIORITY_THREAD_POOL;
 import static com.thulawa.kafka.internals.helpers.ThreadPoolRegistry.THULAWA_MAIN_THREAD_POOL;
 
-
-public class ThulawaScheduler implements Scheduler{
+public class ThulawaScheduler implements Scheduler {
 
     private static final Logger logger = LoggerFactory.getLogger(ThulawaScheduler.class);
 
@@ -23,38 +26,38 @@ public class ThulawaScheduler implements Scheduler{
     private final ThreadPoolRegistry threadPoolRegistry;
     private final ThulawaTaskManager thulawaTaskManager;
     private final Processor processor;
+    private final Set<String> highPriorityKeySet;
 
     private final ThulawaMetrics thulawaMetrics;
 
     private State state;
 
     private ThulawaScheduler(QueueManager queueManager, ThreadPoolRegistry threadPoolRegistry, ThulawaTaskManager thulawaTaskManager,
-                             ThulawaMetrics thulawaMetrics, Processor processor) {
+                             ThulawaMetrics thulawaMetrics, Processor processor, Set<String> highPriorityKeySet) {
         this.queueManager = queueManager;
         this.threadPoolRegistry = threadPoolRegistry;
         this.thulawaTaskManager = thulawaTaskManager;
         this.thulawaMetrics = thulawaMetrics;
         this.processor = processor;
+        this.highPriorityKeySet = highPriorityKeySet;
         this.state = State.CREATED;
 
         this.queueManager.setSchedulerObserver(this);
     }
 
     public static synchronized ThulawaScheduler getInstance(QueueManager queueManager, ThreadPoolRegistry threadPoolRegistry, ThulawaTaskManager thulawaTaskManager,
-                                                            ThulawaMetrics thulawaMetrics, Processor processor) {
+                                                            ThulawaMetrics thulawaMetrics, Processor processor, Set<String> highPriorityKeySet) {
         if (instance == null) {
-            instance = new ThulawaScheduler(queueManager, threadPoolRegistry, thulawaTaskManager, thulawaMetrics, processor);
+            instance = new ThulawaScheduler(queueManager, threadPoolRegistry, thulawaTaskManager, thulawaMetrics, processor, highPriorityKeySet);
         }
         return instance;
     }
 
     /**
-     *  1. Listens for arriving events .
-     *  2. Listen for JVM Metrics.
-     *  3. Update the ThulawaTaskManager with the necessary tasks.
-     *  eg - Dynamically manage the Runnable Task slots based on thread busyness.
-     *  4. Create or Delete thread based on the requirements.
-     *
+     * 1. Listens for arriving events.
+     * 2. Distributes events between HIGH_PRIORITY and LOW_PRIORITY threads.
+     * 3. Updates the ThulawaTaskManager dynamically based on queue activity.
+     * 4. Creates or deletes threads based on requirements.
      */
     public void schedule() {
         this.state = State.ACTIVE;
@@ -62,16 +65,32 @@ public class ThulawaScheduler implements Scheduler{
 
         while (this.state == State.ACTIVE) {
             try {
-                int availableRecordsInQueues = queueManager.getAvailableRecordsInQueuesSize();
-
-                if (availableRecordsInQueues > 0) {
-                    ThulawaTask thulawaTask = new ThulawaTask(HIGH_PRIORITY_THREAD_POOL,
-                            queueManager.getRecordFromQueue("__NULL_KEY__"),
-                            () -> processor.process(queueManager.getRecordFromQueue("__NULL_KEY__")));
-                    this.thulawaTaskManager.addActiveTask(HIGH_PRIORITY_THREAD_POOL, thulawaTask);
+                // High-priority processing
+                for (String highPriorityKey : highPriorityKeySet) {
+                    Record record = queueManager.getRecordFromQueue(highPriorityKey);
+                    if (record != null) {
+                        ThulawaTask highPriorityTask = new ThulawaTask(
+                                HIGH_PRIORITY_THREAD_POOL,
+                                record,
+                                () -> processor.process(record)
+                        );
+                        thulawaTaskManager.addActiveTask(HIGH_PRIORITY_THREAD_POOL, highPriorityTask);
+                    }
                 }
+
+                // Low-priority processing
+                Record lowPriorityRecord = queueManager.getRecordFromQueue("low.priority.keys");
+                if (lowPriorityRecord != null) {
+                    ThulawaTask lowPriorityTask = new ThulawaTask(
+                            LOW_PRIORITY_THREAD_POOL,
+                            lowPriorityRecord,
+                            () -> processor.process(lowPriorityRecord)
+                    );
+                    thulawaTaskManager.addActiveTask(LOW_PRIORITY_THREAD_POOL, lowPriorityTask);
+                }
+
             } catch (Exception e) {
-                logger.error("Error in scheduler: {}", e.getMessage());
+                logger.error("Error in scheduler: {}", e.getMessage(), e);
                 Thread.currentThread().interrupt();
             }
         }
@@ -101,11 +120,10 @@ public class ThulawaScheduler implements Scheduler{
         return this.state == State.ACTIVE;
     }
 
-    private enum State{
+    private enum State {
         CREATED,
         ACTIVE,
         INACTIVE,
         DEAD
     }
-
 }


### PR DESCRIPTION
With the following implementation, Records are distributed among Queues based on the priority of the Key. For each high priority key a separate Queue is created and all other keys are sent to the low priority queue.

This works fine with the multi-threaded implementation, just have to manage the thread queue size, and of threads